### PR TITLE
Beat Condition

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "BeatNet"]
+	path = BeatNet
+	url = https://github.com/yocontra/BeatNet

--- a/audiocraft/models/builders.py
+++ b/audiocraft/models/builders.py
@@ -157,6 +157,7 @@ def get_conditioner_provider(output_dim: int, cfg: omegaconf.DictConfig) -> Cond
             conditioners[str(cond)] = BeatConditioner(
                 output_dim=output_dim,
                 device=device,
+                duration=duration,
                 **model_args
             )
         else:

--- a/audiocraft/models/builders.py
+++ b/audiocraft/models/builders.py
@@ -156,7 +156,6 @@ def get_conditioner_provider(output_dim: int, cfg: omegaconf.DictConfig) -> Cond
         elif model_type == 'beat':
             conditioners[str(cond)] = BeatConditioner(
                 output_dim=output_dim,
-                duration=duration,
                 device=device,
                 **model_args
             )

--- a/audiocraft/models/builders.py
+++ b/audiocraft/models/builders.py
@@ -33,6 +33,7 @@ from ..modules.conditioners import (
     ConditioningProvider,
     LUTConditioner,
     T5Conditioner,
+    BeatConditioner
 )
 from .unet import DiffusionUnet
 from .. import quantization as qt
@@ -149,6 +150,13 @@ def get_conditioner_provider(output_dim: int, cfg: omegaconf.DictConfig) -> Cond
         elif model_type == 'clap':
             conditioners[str(cond)] = CLAPEmbeddingConditioner(
                 output_dim=output_dim,
+                device=device,
+                **model_args
+            )
+        elif model_type == 'beat':
+            conditioners[str(cond)] = BeatConditioner(
+                output_dim=output_dim,
+                duration=duration,
                 device=device,
                 **model_args
             )

--- a/audiocraft/modules/beat.py
+++ b/audiocraft/modules/beat.py
@@ -93,7 +93,7 @@ class BeatExtractor(nn.Module):
         T = wav.shape[-1]
 
         if T < 4096:
-            frames = np.zeros((1, 2))
+            frames = torch.zeros((2, 1))
         else:
             beats = self.estimator.offline_process(wav, self.sample_rate)
             beat_times = beats[:, 0]

--- a/audiocraft/modules/beat.py
+++ b/audiocraft/modules/beat.py
@@ -6,11 +6,59 @@ from torch import nn
 import librosa
 from BeatNet.BeatNet import BeatNet
 
+class BeatExtractor(nn.Module):
+    """Beat extraction and time ramp generation.
+
+        Extract beats using BeatNet[1]. Assign beats on a per-frame basis, 
+        where frames with a beat are assigned 1. Between beats is a ramp 
+        from 0 to 1 indicating the metrical position within the beat.
+
+        Args:
+            sample_rate (int): Sample rate for beat extraction
+            hop_size (int): subsampling period for beat resolution
+        
+        Resource:
+        [1] Heydari, Mojtaba, Frank Cwitkowitz, and Zhiyao Duan. “BeatNet: 
+        CRNN and Particle Filtering for Online Joint Beat Downbeat and Meter 
+        Tracking.” arXiv, August 8, 2021. http://arxiv.org/abs/2108.03576.
+
+    """
+    def __init__(self,
+                 sample_rate: int,
+                 hop_size: int = 512):
+        self.sample_rate = sample_rate
+        self.hop_size = hop_size
+        self.estimator = BeatNet(1, mode='offline', inference_model='DBN', plot=[], thread=False)
+
+    def forward(self, wav: torch.Tensor):
+        beats = estimator.offline_process(wav, self.sample_rate)
+        beat_times = beats[:, 0]
+        beat_positions = beats[:, 1]
+        
+        duration = len(wav)/self.sample_rate
+        hop_times = np.linspace(0, duration, len(wav))
+        frames = np.zeros_like(hop_times)
+
+        # find frames that contain beats
+        for n in len(hop_times):
+            if any([t >= hop_times[n] and t < hop_times[n+1] for t in beats['times']]):
+                frames[n] = 1
+
+        frames_with_beats = np.where(frames)[0]
+        for n, _ in enumerate(frames_with_beats[:-1]):
+            start = frames_with_beats[n]+1
+            end = frames_with_beats[n+1]
+            frames[start:end] = np.linspace(0, 1, end-start, False)
+
+        return torch.from_numpy(frames)
+
+
 estimator = BeatNet(1, mode='offline', inference_model='DBN', plot=[], thread=False)
 
-file = "path/to/audio.wav"
+# file = "path/to/audio.wav"
+file = "/Users/julianvanasse/Development/datasets/testdrums/120bpm.wav"
 audio, sample_rate = librosa.load(file, mono=True)
-beats = estimator.process(file)
+beats = estimator.offline_process(audio=audio, sample_rate=sample_rate)
 beats = {
     "times": beats[:, 0],
     "pos": beats[:, 1]

--- a/audiocraft/modules/beat.py
+++ b/audiocraft/modules/beat.py
@@ -1,0 +1,40 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import torch 
+from torch import nn
+
+import librosa
+from BeatNet.BeatNet import BeatNet
+
+estimator = BeatNet(1, mode='offline', inference_model='DBN', plot=[], thread=False)
+
+file = "path/to/audio.wav"
+audio, sample_rate = librosa.load(file, mono=True)
+beats = estimator.process(file)
+beats = {
+    "times": beats[:, 0],
+    "pos": beats[:, 1]
+}
+
+duration = len(audio)/sample_rate
+
+hop_size = 512
+hop_times = np.arange(start=0, stop=duration, step=hop_size/sample_rate)
+frames = np.zeros_like(hop_times)
+
+for n, _ in enumerate(hop_times[:-1]):
+    if any([t >= hop_times[n] and t < hop_times[n+1] for t in beats['times']]):
+        frames[n] = 1
+
+frames_with_beats = np.where(frames)[0]
+for n, _ in enumerate(frames_with_beats[:-1]):
+    start = frames_with_beats[n]+1
+    end = frames_with_beats[n+1]
+    frames[start:end] = np.linspace(0, 1, end-start, False)
+
+
+t = np.linspace(0, len(audio)/sample_rate, len(audio), False)
+plt.plot(t, audio)
+# plt.vlines(x=beats['times'], ymin=-1, ymax=1, colors='r')
+plt.plot(hop_times, frames)
+plt.show()

--- a/audiocraft/modules/beat.py
+++ b/audiocraft/modules/beat.py
@@ -93,7 +93,7 @@ class BeatExtractor(nn.Module):
         if T < 4096:
             frames = torch.zeros((2, 1))
         else:
-            beats = self.estimator.process_offline(wav, self.sample_rate)
+            beats = self.estimator.process_offline(wav.detach().numpy(), self.sample_rate)
             beat_times = beats[:, 0]
             beat_positions = beats[:, 1]
             
@@ -102,7 +102,7 @@ class BeatExtractor(nn.Module):
                                     hop_size=self.hop_size,
                                     beat_times=beat_times,
                                     beat_positions=beat_positions)
-        
+
         return frames
 
 def main():

--- a/audiocraft/modules/beat.py
+++ b/audiocraft/modules/beat.py
@@ -91,9 +91,11 @@ class BeatExtractor(nn.Module):
 
     def forward(self, wav: torch.Tensor):
         T = wav.shape[-1]
+        num_frames = int(np.ceil(T / self.hop_size))
+        beat_feature = torch.zeros(size=(1, num_frames, 2))
 
         if T < 4096:
-            frames = torch.zeros((1, 2))
+            pass
         else:
             beats = self.estimator.get_beats(audio=wav, sample_rate=self.sample_rate)
             # beats = self.estimator.process_offline(wav.cpu().numpy().T, self.sample_rate)
@@ -104,10 +106,11 @@ class BeatExtractor(nn.Module):
                                     sample_rate=self.sample_rate, 
                                     hop_size=self.hop_size,
                                     beat_times=beat_times,
-                                    beat_positions=beat_positions)
-            frames = frames.T
+                                    beat_positions=beat_positions).T
+            
+            beat_feature = frames.unsqueeze(0)
 
-        return frames
+        return beat_feature
 
 def main():
     import os 

--- a/audiocraft/modules/beat.py
+++ b/audiocraft/modules/beat.py
@@ -37,18 +37,21 @@ class BeatExtractor(nn.Module):
         
         duration = len(wav)/self.sample_rate
         hop_times = np.linspace(0, duration, len(wav))
-        frames = np.zeros_like(hop_times)
+        num_hops = len(hop_times)
+        frames = np.zeros((2, num_hops))
 
         # find frames that contain beats
         for n in range(len(hop_times[:-1])):
             if any([t >= hop_times[n] and t < hop_times[n+1] for t in beat_times]):
-                frames[n] = 1
+                frames[0, n] = 1
+                if beat_positions[n] == 1:
+                    frames[1, n] = 1
 
         frames_with_beats = np.where(frames)[0]
         for n, _ in enumerate(frames_with_beats[:-1]):
             start = frames_with_beats[n]+1
             end = frames_with_beats[n+1]
-            frames[start:end] = np.linspace(0, 1, end-start, False)
+            frames[0, start:end] = np.linspace(0, 1, end-start, False)
 
         return torch.from_numpy(frames)
 

--- a/audiocraft/modules/beat.py
+++ b/audiocraft/modules/beat.py
@@ -32,10 +32,14 @@ class BeatExtractor(nn.Module):
         self.estimator = BeatNet(1, mode='offline', inference_model='DBN', plot=[], thread=False)
 
     def forward(self, wav: torch.Tensor):
-        if len(wav) < 4096:
+        T = wav.shape[-1]
+        print(T)
+        if T < 4096:
             frames = np.zeros((1, 2))
         else:
-            beats = self.estimator.offline_process(wav.cpu().numpy(), self.sample_rate)
+            signal = wav.cpu().numpy()
+            signal = np.squeeze(signal)
+            beats = self.estimator.offline_process(signal, self.sample_rate)
             beat_times = beats[:, 0]
             beat_positions = beats[:, 1]
             
@@ -56,8 +60,11 @@ class BeatExtractor(nn.Module):
                 start = frames_with_beats[n]+1
                 end = frames_with_beats[n+1]
                 frames[0, start:end] = np.linspace(0, 1, end-start, False)
+            frames = frames.T
 
-        return torch.from_numpy(frames)
+        frames = torch.from_numpy(frames)
+        
+        return frames
 
 if __name__ == "__main__":
     file = "path/to/audio.wav"

--- a/audiocraft/modules/conditioners.py
+++ b/audiocraft/modules/conditioners.py
@@ -507,52 +507,7 @@ class WaveformConditioner(BaseConditioner):
         embeds = (embeds * mask.unsqueeze(-1))
         return embeds, mask
     
-# class BeatConditioner(WaveformConditioner):
-#     """Downbeat/upbeat conditioner.
-
-#     """
-#     def __init__(self, 
-#                  output_dim: int,
-#                  num_classes: int,
-#                  sample_rate: int,
-#                  hop_size: int,
-#                  device: tp.Union[torch.device, str]='cpu',
-#                  cache_path: tp.Optional[tp.Union[str, Path]]=None,
-#                  **kwargs):
-#         super().__init__(dim=num_classes, output_dim=output_dim, device=device)
-#         self.hop_size = hop_size
-#         self.sample_rate = sample_rate
-#         self.beat_estimator = BeatExtractor(self.sample_rate, self.hop_size, device=device)
-#         if cache_path is not None:
-#             self.cache = EmbeddingCache(Path(cache_path) / 'wav', self.device,
-#                                         compute_embed_fn=self._get_wav_embedding,
-#                                         extract_embed_fn=self._extract_beatramp_chunk)
-
-#     def _get_wav_embedding(self, x: WavCondition) -> torch.Tensor:
-#         # x.wav will be [B, C, T] in shape
-#         # return a tensor that is [B, N, F], where B is batch, N is frames (subsamples) and 
-#         #                                    F is the number of features (output_dim) 
-#         return self.beat_estimator.forward(x.wav)
     
-#     def _downsampling_factor(self):
-#         return self.hop_size
-    
-#     def _extract_beatramp_chunk(self, beatramp: torch.Tensor, x: WavCondition, idx: int) -> torch.Tensor:
-#         """Extract a chunk of beatramp from the full beatramp derived from the full waveform."""
-#         wav_length = x.wav.shape[-1]
-#         seek_time = x.seek_time[idx]
-#         assert seek_time is not None, (
-#             "WavCondition seek_time is required "
-#             "when extracting beatramp chunks from pre-computed beatramp.")
-#         beatramp = beatramp.float()
-#         frame_rate = self.sample_rate / self._downsampling_factor()
-#         target_length = int(frame_rate * wav_length / self.sample_rate)
-#         index = int(frame_rate * seek_time)
-#         out = beatramp[index: index + target_length]
-#         out = F.pad(out[None], (0, 0, 0, target_length - out.shape[0]))[0]
-#         return out.to(self.device)
-    
-
 class BeatConditioner(WaveformConditioner):
     """Beat conditioner based on beat and downbeat prediction
     

--- a/audiocraft/modules/conditioners.py
+++ b/audiocraft/modules/conditioners.py
@@ -505,6 +505,25 @@ class WaveformConditioner(BaseConditioner):
             mask = torch.ones_like(embeds[..., 0])
         embeds = (embeds * mask.unsqueeze(-1))
         return embeds, mask
+    
+class BeatConditioner(WaveformConditioner):
+    """Downbeat/upbeat conditioner.
+    TODO: Beat data extracted from audio using BeatNet.
+    """
+    def __init__(self, 
+                 output_dim: int,
+                 num_classes: int,
+                 hop_size: int,
+                 device: tp.Union[torch.device, str]='cpu'):
+        super().__init__(dim=num_classes, output_dim=output_dim, device=device)
+        self.hop_size = hop_size
+
+    def _get_wav_embedding(self, x: WavCondition) -> torch.Tensor:
+        return torch.zeros([1, self.dim])
+    
+    def _downsampling_factor(self):
+        return self.hop_size
+
 
 
 class ChromaStemConditioner(WaveformConditioner):

--- a/audiocraft/modules/conditioners.py
+++ b/audiocraft/modules/conditioners.py
@@ -522,7 +522,7 @@ class BeatConditioner(WaveformConditioner):
         super().__init__(dim=num_classes, output_dim=output_dim, device=device)
         self.hop_size = hop_size
         self.sample_rate = sample_rate
-        self.beat_estimator = BeatExtractor(self.sample_rate, self.hop_size)
+        self.beat_estimator = BeatExtractor(self.sample_rate, self.hop_size, device=device)
         if cache_path is not None:
             self.cache = EmbeddingCache(Path(cache_path) / 'wav', self.device,
                                         compute_embed_fn=self._get_wav_embedding,

--- a/audiocraft/modules/conditioners.py
+++ b/audiocraft/modules/conditioners.py
@@ -507,53 +507,212 @@ class WaveformConditioner(BaseConditioner):
         embeds = (embeds * mask.unsqueeze(-1))
         return embeds, mask
     
+# class BeatConditioner(WaveformConditioner):
+#     """Downbeat/upbeat conditioner.
+
+#     """
+#     def __init__(self, 
+#                  output_dim: int,
+#                  num_classes: int,
+#                  sample_rate: int,
+#                  hop_size: int,
+#                  device: tp.Union[torch.device, str]='cpu',
+#                  cache_path: tp.Optional[tp.Union[str, Path]]=None,
+#                  **kwargs):
+#         super().__init__(dim=num_classes, output_dim=output_dim, device=device)
+#         self.hop_size = hop_size
+#         self.sample_rate = sample_rate
+#         self.beat_estimator = BeatExtractor(self.sample_rate, self.hop_size, device=device)
+#         if cache_path is not None:
+#             self.cache = EmbeddingCache(Path(cache_path) / 'wav', self.device,
+#                                         compute_embed_fn=self._get_wav_embedding,
+#                                         extract_embed_fn=self._extract_beatramp_chunk)
+
+#     def _get_wav_embedding(self, x: WavCondition) -> torch.Tensor:
+#         # x.wav will be [B, C, T] in shape
+#         # return a tensor that is [B, N, F], where B is batch, N is frames (subsamples) and 
+#         #                                    F is the number of features (output_dim) 
+#         return self.beat_estimator.forward(x.wav)
+    
+#     def _downsampling_factor(self):
+#         return self.hop_size
+    
+#     def _extract_beatramp_chunk(self, beatramp: torch.Tensor, x: WavCondition, idx: int) -> torch.Tensor:
+#         """Extract a chunk of beatramp from the full beatramp derived from the full waveform."""
+#         wav_length = x.wav.shape[-1]
+#         seek_time = x.seek_time[idx]
+#         assert seek_time is not None, (
+#             "WavCondition seek_time is required "
+#             "when extracting beatramp chunks from pre-computed beatramp.")
+#         beatramp = beatramp.float()
+#         frame_rate = self.sample_rate / self._downsampling_factor()
+#         target_length = int(frame_rate * wav_length / self.sample_rate)
+#         index = int(frame_rate * seek_time)
+#         out = beatramp[index: index + target_length]
+#         out = F.pad(out[None], (0, 0, 0, target_length - out.shape[0]))[0]
+#         return out.to(self.device)
+    
+
 class BeatConditioner(WaveformConditioner):
-    """Downbeat/upbeat conditioner.
-    TODO: Beat data extracted from audio using BeatNet.
+    """Beat conditioner based on beat and downbeat prediction
+    
+
     """
     def __init__(self, 
-                 output_dim: int,
-                 num_classes: int,
-                 sample_rate: int,
+                 output_dim: int, 
+                 sample_rate: int, 
                  hop_size: int,
-                 device: tp.Union[torch.device, str]='cpu',
-                 cache_path: tp.Optional[tp.Union[str, Path]]=None,
+                 num_classes: int, 
+                 duration: float, 
+                 match_len_on_eval: bool = True, 
+                 eval_wavs: tp.Optional[str] = None,
+                 n_eval_wavs: int = 0, 
+                 cache_path: tp.Optional[tp.Union[str, Path]] = None,
+                 device: tp.Union[torch.device, str] = 'cpu', 
                  **kwargs):
+        
         super().__init__(dim=num_classes, output_dim=output_dim, device=device)
         self.hop_size = hop_size
         self.sample_rate = sample_rate
+        self.autocast = TorchAutocast(enabled=device != 'cpu', device_type=self.device, dtype=torch.float32)
+        self.sample_rate = sample_rate
+        self.match_len_on_eval = match_len_on_eval
+
+        if match_len_on_eval:
+            self._use_masking = False 
+        self.duration = duration
+
         self.beat_estimator = BeatExtractor(self.sample_rate, self.hop_size, device=device)
+        
+        self.feature_len = self._get_beat_feature_len()
+        self.eval_wavs: tp.Optional[torch.Tensor] = self._load_eval_wavs(eval_wavs, n_eval_wavs)
+        self.cache = None
         if cache_path is not None:
             self.cache = EmbeddingCache(Path(cache_path) / 'wav', self.device,
-                                        compute_embed_fn=self._get_wav_embedding,
-                                        extract_embed_fn=self._extract_beatramp_chunk)
+                                        compute_embed_fn=self._get_full_chroma_for_cache,
+                                        extract_embed_fn=self._extract_chroma_chunk)
 
-    def _get_wav_embedding(self, x: WavCondition) -> torch.Tensor:
-        # x.wav will be [B, C, T] in shape
-        # return a tensor that is [B, N, F], where B is batch, N is frames (subsamples) and 
-        #                                    F is the number of features (output_dim) 
-        return self.beat_estimator.forward(x.wav)
-    
-    def _downsampling_factor(self):
+    def _downsampling_factor(self) -> int:
         return self.hop_size
-    
-    def _extract_beatramp_chunk(self, beatramp: torch.Tensor, x: WavCondition, idx: int) -> torch.Tensor:
-        """Extract a chunk of beatramp from the full beatramp derived from the full waveform."""
+
+    def _load_eval_wavs(self, path: tp.Optional[str], num_samples: int) -> tp.Optional[torch.Tensor]:
+        """Load pre-defined waveforms from a json.
+        These waveforms will be used for chroma extraction during evaluation.
+        This is done to make the evaluation on MusicCaps fair (we shouldn't see the chromas of MusicCaps).
+        """
+        if path is None:
+            return None
+
+        logger.info(f"Loading evaluation wavs from {path}")
+        from audiocraft.data.audio_dataset import AudioDataset
+        dataset: AudioDataset = AudioDataset.from_meta(
+            path, segment_duration=self.duration, min_audio_duration=self.duration,
+            sample_rate=self.sample_rate, channels=1)
+
+        if len(dataset) > 0:
+            eval_wavs = dataset.collater([dataset[i] for i in range(num_samples)]).to(self.device)
+            logger.info(f"Using {len(eval_wavs)} evaluation wavs for chroma-stem conditioner")
+            return eval_wavs
+        else:
+            raise ValueError("Could not find evaluation wavs, check lengths of wavs")
+
+    def reset_eval_wavs(self, eval_wavs: tp.Optional[torch.Tensor]) -> None:
+        self.eval_wavs = eval_wavs
+
+    def has_eval_wavs(self) -> bool:
+        return self.eval_wavs is not None
+
+    def _sample_eval_wavs(self, num_samples: int) -> torch.Tensor:
+        """Sample wavs from a predefined list."""
+        assert self.eval_wavs is not None, "Cannot sample eval wavs as no eval wavs provided."
+        total_eval_wavs = len(self.eval_wavs)
+        out = self.eval_wavs
+        if num_samples > total_eval_wavs:
+            out = self.eval_wavs.repeat(num_samples // total_eval_wavs + 1, 1, 1)
+        return out[torch.randperm(len(out))][:num_samples]
+
+    def _get_beat_feature_len(self) -> int:
+        """Get length of beat during training."""
+        dummy_wav = torch.zeros((1, int(self.sample_rate * self.duration)), device=self.device)
+        dummy_chr = self.beat_estimator(dummy_wav)
+        return dummy_chr.shape[1]
+
+    @torch.no_grad()
+    def _compute_wav_embedding(self, wav: torch.Tensor, sample_rate: int) -> torch.Tensor:
+        """Compute wav embedding, applying stem and chroma extraction."""
+        # avoid 0-size tensors when we are working with null conds
+        if wav.shape[-1] == 1:
+            return self.beat_estimator(wav)
+        beat_ramps = self.beat_estimator(wav)
+        return beat_ramps
+
+    @torch.no_grad()
+    def _get_full_chroma_for_cache(self, path: tp.Union[str, Path], x: WavCondition, idx: int) -> torch.Tensor:
+        """Extract chroma from the whole audio waveform at the given path."""
+        wav, sr = audio_read(path)
+        wav = wav[None].to(self.device)
+        wav = convert_audio(wav, sr, self.sample_rate, to_channels=1)
+        chroma = self._compute_wav_embedding(wav, self.sample_rate)[0]
+        return chroma
+
+    def _extract_chroma_chunk(self, full_chroma: torch.Tensor, x: WavCondition, idx: int) -> torch.Tensor:
+        """Extract a chunk of chroma from the full chroma derived from the full waveform."""
         wav_length = x.wav.shape[-1]
         seek_time = x.seek_time[idx]
         assert seek_time is not None, (
             "WavCondition seek_time is required "
-            "when extracting beatramp chunks from pre-computed beatramp.")
-        beatramp = beatramp.float()
+            "when extracting chroma chunks from pre-computed chroma.")
+        full_chroma = full_chroma.float()
         frame_rate = self.sample_rate / self._downsampling_factor()
         target_length = int(frame_rate * wav_length / self.sample_rate)
         index = int(frame_rate * seek_time)
-        out = beatramp[index: index + target_length]
+        out = full_chroma[index: index + target_length]
         out = F.pad(out[None], (0, 0, 0, target_length - out.shape[0]))[0]
         return out.to(self.device)
-    
 
+    @torch.no_grad()
+    def _get_wav_embedding(self, x: WavCondition) -> torch.Tensor:
+        """Get the wav embedding from the WavCondition.
+        The conditioner will either extract the embedding on-the-fly computing it from the condition wav directly
+        or will rely on the embedding cache to load the pre-computed embedding if relevant.
+        """
+        sampled_wav: tp.Optional[torch.Tensor] = None
+        if not self.training and self.eval_wavs is not None:
+            warn_once(logger, "Using precomputed evaluation wavs!")
+            sampled_wav = self._sample_eval_wavs(len(x.wav))
 
+        no_undefined_paths = all(p is not None for p in x.path)
+        no_nullified_cond = x.wav.shape[-1] > 1
+        if sampled_wav is not None:
+            beat_features = self._compute_wav_embedding(sampled_wav, self.sample_rate)
+        elif self.cache is not None and no_undefined_paths and no_nullified_cond:
+            paths = [Path(p) for p in x.path if p is not None]
+            beat_features = self.cache.get_embed_from_cache(paths, x)
+        else:
+            assert all(sr == x.sample_rate[0] for sr in x.sample_rate), "All sample rates in batch should be equal."
+            beat_features = self._compute_wav_embedding(x.wav, x.sample_rate[0])
+
+        if self.match_len_on_eval:
+            B, T, C = beat_features.shape
+            if T > self.feature_len:
+                beat_features = beat_features[:, :self.feature_len]
+                logger.debug(f"beat_features was truncated to match length! ({T} -> {beat_features.shape[1]})")
+            elif T < self.feature_len:
+                n_repeat = int(math.ceil(self.feature_len / T))
+                beat_features = beat_features.repeat(1, n_repeat, 1)
+                beat_features = beat_features[:, :self.feature_len]
+                logger.debug(f"beat_features repeated to match length! ({T} -> {beat_features.shape[1]})")
+
+        return beat_features
+
+    def tokenize(self, x: WavCondition) -> WavCondition:
+        """Apply WavConditioner tokenization and populate cache if needed."""
+        x = super().tokenize(x)
+        no_undefined_paths = all(p is not None for p in x.path)
+        if self.cache is not None and no_undefined_paths:
+            paths = [Path(p) for p in x.path if p is not None]
+            self.cache.populate_embed_cache(paths, x)
+        return x
 
 
 class ChromaStemConditioner(WaveformConditioner):

--- a/audiocraft/modules/conditioners.py
+++ b/audiocraft/modules/conditioners.py
@@ -529,6 +529,9 @@ class BeatConditioner(WaveformConditioner):
                                         extract_embed_fn=self._extract_beatramp_chunk)
 
     def _get_wav_embedding(self, x: WavCondition) -> torch.Tensor:
+        # x.wav will be [B, C, T] in shape
+        # return a tensor that is [B, N, F], where B is batch, N is frames (subsamples) and 
+        #                                    F is the number of features (output_dim) 
         return self.beat_estimator.forward(x.wav)
     
     def _downsampling_factor(self):

--- a/config/conditioner/beat2music.yaml
+++ b/config/conditioner/beat2music.yaml
@@ -26,6 +26,10 @@ conditioners:
       num_classes: 2
       hop_size: 1024
       sample_rate: ${sample_rate}
+      match_len_on_eval: false
+      eval_wavs: null
+      n_eval_wavs: 100
+      cache_path: null
   description:
     model: t5
     t5:

--- a/config/conditioner/beat2music.yaml
+++ b/config/conditioner/beat2music.yaml
@@ -23,10 +23,9 @@ conditioners:
   self_wav:
     model: beat
     beat:
-      num_classes: 3
+      num_classes: 2
       hop_size: 1024
-      arg0: null
-      arg1: "hello"
+      sample_rate: ${sample_rate}
   description:
     model: t5
     t5:

--- a/config/conditioner/beat2music.yaml
+++ b/config/conditioner/beat2music.yaml
@@ -22,15 +22,9 @@ fuser:
 conditioners:
   self_wav:
     model: beat
-    chroma_stem:
-      sample_rate: ${sample_rate}
-      n_chroma: 12
-      radix2_exp: 14
-      argmax: true
-      match_len_on_eval: false
-      eval_wavs: null
-      n_eval_wavs: 100
-      cache_path: null
+    beat:
+      arg0: null
+      arg1: "hello"
   description:
     model: t5
     t5:

--- a/config/conditioner/beat2music.yaml
+++ b/config/conditioner/beat2music.yaml
@@ -1,0 +1,46 @@
+# @package __global__
+
+classifier_free_guidance:
+  training_dropout: 0.2
+  inference_coef: 3.0
+
+attribute_dropout:
+  args:
+    active_on_eval: false
+  text: {}
+  wav:
+    self_wav: 0.5
+
+fuser:
+  cross_attention_pos_emb: false
+  cross_attention_pos_emb_scale: 1
+  sum: []
+  prepend: [self_wav, description]
+  cross: []
+  input_interpolate: []
+
+conditioners:
+  self_wav:
+    model: beat
+    chroma_stem:
+      sample_rate: ${sample_rate}
+      n_chroma: 12
+      radix2_exp: 14
+      argmax: true
+      match_len_on_eval: false
+      eval_wavs: null
+      n_eval_wavs: 100
+      cache_path: null
+  description:
+    model: t5
+    t5:
+      name: t5-base
+      finetune: false
+      word_dropout: 0.2
+      normalize_text: false
+
+dataset:
+  train:
+    merge_text_p: 0.25
+    drop_desc_p: 0.5
+    drop_other_p: 0.5

--- a/config/conditioner/beat2music.yaml
+++ b/config/conditioner/beat2music.yaml
@@ -23,6 +23,8 @@ conditioners:
   self_wav:
     model: beat
     beat:
+      num_classes: 3
+      hop_size: 1024
       arg0: null
       arg1: "hello"
   description:

--- a/extras/.vscode
+++ b/extras/.vscode
@@ -1,0 +1,28 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: Current File with Arguments",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "args": "${command:pickArgs}"
+        },
+        {
+            "name": "beat2music",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "dora",
+            "args": [
+                "run",
+                "-d",
+                "solver=musicgen/musicgen_base_32khz",
+                "model/lm/model_scale=small",
+                "conditioner=beat2music",
+                "dset=audio/data"
+            ],
+            "justMyCode": false
+        }
+    ]
+}


### PR DESCRIPTION
Added `beat2music.yaml` and all necessary changes within `audiocraft` to enable conditioning audio on rhythm and text.

- added `beat.py` to `audiocraft/modules`
   - uses `BeatNet` package, installed in `requirements.txt`
- added class `BeatConditioner` to `audiocraft/modules/conditions.py`, modeled on class `ChromaStemCondition`
- modifications to `audiocraft/models/builders.py` 
   - import `BeatConditioner`
   - added `beat` to branching conditional in `get_conditioner_provider(...)`